### PR TITLE
users/search.jsonから鍵アカ判定を行うように変更

### DIFF
--- a/motemote/calculate_mote/form.py
+++ b/motemote/calculate_mote/form.py
@@ -48,9 +48,13 @@ def __is_vaild_screen_name(screen_name):
     return True
 
 def __is_protected_user(screen_name):
-    params = {"screen_name": screen_name}
-    req = twitter_api.get_instance("users/show.json", params=params)
-    protected = req.json().get('protected', False)
+    params = {"q": screen_name, 'page':1, 'count':10}
+    req = twitter_api.get_instance("users/search.json", params=params)
+
+    protected = False
+    for f in req.json():
+        if f['screen_name']  == screen_name:
+            protected = f.get('protected', False)
     return protected
 
 


### PR DESCRIPTION
サーバ上でバグ #47 が発生し、原因が判明しなかったので別のAPIを使いました。
具体的には、screen_nameのフォームの鍵アカ判定関数の処理を変更しました。

 - ツイッターAPIを`users/show.json`から`users/search.json`に変更